### PR TITLE
Generate executable file with version number

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -60,7 +60,7 @@ jobs:
           semver = match.group(0)
           version = f'{semver}-${{steps.vars.outputs.source_branch}}'
 
-          print(f'::set-output name=ARTIFACT_NAME::migrator-{version}-win-x64')
+          print(f'::set-output name=artifact_name::migrator-{version}-win-x64')
 
           filepath = './windows/runner/Runner.rc'
           

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -100,7 +100,7 @@ jobs:
       - uses: actions/create-release@v1
         name: Create Release
         id: create_release
-        if: $CREATE_RELEASE
+        if: env.CREATE_RELEASE
         env:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
         with:
@@ -111,13 +111,13 @@ jobs:
       - uses: actions/download-artifact@v2
         name: Download artifact
         id: download
-        if: $CREATE_RELEASE
+        if: env.CREATE_RELEASE
         with:
           name: $ARTIFACT_NAME
 
       - uses: actions/upload-release-asset@v1
         name: Upload Release Asset
-        if: $CREATE_RELEASE
+        if: env.CREATE_RELEASE
         env:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
         with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -99,7 +99,7 @@ jobs:
       - uses: actions/upload-artifact@v2
         name: Upload artifact
         with:
-          name: $ARTIFACT_NAME
+          name: ${{steps.vars2.outputs.artifact_name}}
           path: ${{github.workspace}}/build/windows/runner/Release/
         
       - uses: actions/create-release@v1

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -62,7 +62,7 @@ jobs:
 
           print(f'::set-output name=ARTIFACT_NAME::migrator-{version}-win-x64')
 
-          filepath = '${{github.workspace}}/windows/runner/Runner.rc'.replace('\\', '/')
+          filepath = './windows/runner/Runner.rc'
           
           print(f'::debug Define version in {filepath}')
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,39 +25,56 @@ jobs:
     steps:
       - uses: actions/checkout@v2
         name: Checkout
-      
-      - uses: actions/github-script@v3
-        name: Set source branch name
-        id: set_branch_name
-        with: 
-          result-encoding: string
-          script: return '${{github.head_ref || github.ref}}'.replace('refs/heads/', '')
-          
+
+      - name: Init env vars
+        shell: python
+        run: |
+          import subprocess
+
+          srcBranch = '${{ github.head_ref || github.ref }}'.replace('refs/heads/', '').replace('/', '-')
+          createArtifact = 'true' if srcBranch == 'master' or srcBranch == 'ci' else 'false'
+
+          print('::set-env name=SOURCE_BRANCH::{srcBranch}')
+          print('::set-env name=CREATE_ARTIFACT::{createArtifact}')
+
       - uses: mathieudutour/github-tag-action@v5
         name: Bump version and push tag
         id: tag_version
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }} 
-          append_to_pre_release_tag: ${{steps.set_branch_name.outputs.result}}
+          append_to_pre_release_tag: $SOURCE_BRANCH
           dry_run: ${{!contains(github.ref, 'master')}}
-        
-      - uses: actions/github-script@v3
-        name: Split version
-        id: version_as_number
-        with: 
-          result-encoding: string
-          script: |
-           const parts = '${{steps.tag_version.outputs.new_version}}'.match(/(\d+)\.(\d+)\.(\d+)/)
-           return `${parts[1]},${parts[2]},${parts[2]}`
-                 
-      - uses: bluwy/substitute-string-action@v1
-        name: Define version in Runner.rc
-        with: 
-          _input-file: ${{github.workspace}}/windows/runner/Runner.rc
-          _output-file: ${{github.workspace}}/windows/runner/Runner.rc
-          '1,0,0': '${{steps.version_as_number.outputs.result}}'
-          '1\.0\.0': '${{steps.tag_version.outputs.new_version}}'
-       
+
+      - name: Define version
+        shell: python
+        run: |
+          import re 
+
+          version = '${{steps.tag_version.outputs.new_version}}'
+          match = re.search('(\d+)\.(\d+)\.(\d+)', version)
+          semver = match.group(0)
+          version = f'{semver}-$SOURCE_BRANCH'
+
+          print(f'::set-env name=ARTIFACT_NAME::migrator-{version}-win-x64')
+
+          filepath = '${{github.workspace}}/windows/runner/Runner.rc'.replace('/', '//')
+          
+          print(f'::debug Define version in {filepath}')
+
+          versionAsNumber = semver.replace('.', ',')
+          versionAsString = version
+
+          f = open(filepath, 'r')
+          filedata = f.read()
+          f.close()
+
+          filedata = filedata.replace('VERSION_AS_NUMBER 1,0,0', f'VERSION_AS_STRING {versionAsNumber}')
+          filedata = filedata.replace('VERSION_AS_STRING "1.0.0"', f'VERSION_AS_STRING "{versionAsString}"')
+
+          f = open(filepath, 'w')
+          f.write(filedata)
+          f.close()
+          
       - uses: actions/setup-java@v1
         name: Setup Java
         with:
@@ -73,38 +90,38 @@ jobs:
       - run: flutter pub run build_runner build —delete-conflicting-outputs
       #- run: flutter test
       - run: flutter build windows
-             
-      - uses: papeloto/action-zip@v1
-        name: Create artifact
-        with:
-          files: build/windows/runner/Release/
-          dest: artifact.zip
-          
+
       - uses: actions/upload-artifact@v2
         name: Upload artifact
         with:
-          name: migrator-${{ steps.tag_version.outputs.new_version }}-win-x64
-          path: ${{github.workspace}}/artifact.zip
+          name: $ARTIFACT_NAME
+          path: ${{github.workspace}}/build/windows/runner/Release/
         
       - uses: actions/create-release@v1
         name: Create Release
         id: create_release
-        if: github.ref == 'refs/heads/master'
+        if: $CREATE_RELEASE
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
         with:
           draft: true
-          tag_name: ${{ steps.tag_version.outputs.new_tag }}
-          release_name: Release ${{ steps.tag_version.outputs.new_tag }}
-          body: ${{ steps.tag_version.outputs.changelog }}
-     
+          tag_name: ${{steps.tag_version.outputs.new_tag}}
+          release_name: Release ${{steps.tag_version.outputs.new_tag}}
+
+      - uses: actions/download-artifact@v2
+        name: Download artifact
+        id: download
+        if: $CREATE_RELEASE
+        with:
+          name: $ARTIFACT_NAME
+
       - uses: actions/upload-release-asset@v1
         name: Upload Release Asset
-        if: github.ref == 'refs/heads/master'
+        if: $CREATE_RELEASE
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
         with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }} 
-          asset_path: ${{github.workspace}}/artifact.zip
-          asset_name: migrator-${{ steps.tag_version.outputs.new_version }}-win-x64.zip
+          upload_url: ${{steps.create_release.outputs.upload_url}} 
+          asset_path: ${{steps.download.outputs.download-path}}/$ARTIFACT_NAME.zip
+          asset_name: $ARTIFACT_NAME
           asset_content_type: application/zip

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -34,8 +34,8 @@ jobs:
           srcBranch = '${{ github.head_ref || github.ref }}'.replace('refs/heads/', '').replace('/', '-')
           createArtifact = 'true' if srcBranch == 'master' or srcBranch == 'ci' else 'false'
 
-          print('::set-env name=SOURCE_BRANCH::{srcBranch}')
-          print('::set-env name=CREATE_ARTIFACT::{createArtifact}')
+          print(f'::set-env name=SOURCE_BRANCH::{srcBranch}')
+          print(f'::set-env name=CREATE_ARTIFACT::{createArtifact}')
 
       - uses: mathieudutour/github-tag-action@v5
         name: Bump version and push tag

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -73,7 +73,7 @@ jobs:
           filedata = f.read()
           f.close()
 
-          filedata = filedata.replace('VERSION_AS_NUMBER 1,0,0', f'VERSION_AS_STRING {versionAsNumber}')
+          filedata = filedata.replace('VERSION_AS_NUMBER 1,0,0', f'VERSION_AS_NUMBER {versionAsNumber}')
           filedata = filedata.replace('VERSION_AS_STRING "1.0.0"', f'VERSION_AS_STRING "{versionAsString}"')
 
           f = open(filepath, 'w')

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,8 +2,20 @@ name: CI
 on:
   push:
     branches: [ master ]
+    paths-ignore:
+      - '.vscode/**'
+      - '.github/**'
+      - '**.gitignore'
+      - '.metadata'
+      - '.README.md'
   pull_request:
     branches: [ master ]
+    paths-ignore:
+      - '.vscode/**'
+      - '.github/**'
+      - '**.gitignore'
+      - '.metadata'
+      - '.README.md'
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -38,7 +38,7 @@ jobs:
           srcBranch = '${{ github.head_ref || github.ref }}'.replace('refs/heads/', '').replace('/', '-')
           createArtifact = 'true' if srcBranch == 'master' or srcBranch == 'ci' else 'false'
 
-          print(f'::set-output name=source_bracnh::{srcBranch}')
+          print(f'::set-output name=source_branch::{srcBranch}')
           print(f'::set-output name=create_artifact::{createArtifact}')
 
       - uses: mathieudutour/github-tag-action@v5

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -27,6 +27,7 @@ jobs:
         name: Checkout
 
       - name: Init env vars
+        id: vars
         shell: python
         run: |
           import subprocess
@@ -34,18 +35,19 @@ jobs:
           srcBranch = '${{ github.head_ref || github.ref }}'.replace('refs/heads/', '').replace('/', '-')
           createArtifact = 'true' if srcBranch == 'master' or srcBranch == 'ci' else 'false'
 
-          print(f'::set-env name=SOURCE_BRANCH::{srcBranch}')
-          print(f'::set-env name=CREATE_ARTIFACT::{createArtifact}')
+          print(f'::set-output name=source_bracnh::{srcBranch}')
+          print(f'::set-output name=create_artifact::{createArtifact}')
 
       - uses: mathieudutour/github-tag-action@v5
         name: Bump version and push tag
         id: tag_version
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }} 
-          append_to_pre_release_tag: $SOURCE_BRANCH
+          github_token: ${{secrets.GITHUB_TOKEN}} 
+          append_to_pre_release_tag: ${{steps.vars.outputs.source_branch}} 
           dry_run: ${{!contains(github.ref, 'master')}}
 
       - name: Define version
+        id: vars2
         shell: python
         run: |
           import re 
@@ -53,9 +55,9 @@ jobs:
           version = '${{steps.tag_version.outputs.new_version}}'
           match = re.search('(\d+)\.(\d+)\.(\d+)', version)
           semver = match.group(0)
-          version = f'{semver}-$SOURCE_BRANCH'
+          version = f'{semver}-${{steps.vars.outputs.source_branch}}'
 
-          print(f'::set-env name=ARTIFACT_NAME::migrator-{version}-win-x64')
+          print(f'::set-output name=ARTIFACT_NAME::migrator-{version}-win-x64')
 
           filepath = '${{github.workspace}}/windows/runner/Runner.rc'.replace('/', '//')
           
@@ -100,7 +102,7 @@ jobs:
       - uses: actions/create-release@v1
         name: Create Release
         id: create_release
-        if: env.CREATE_RELEASE
+        if: steps.vars.outputs.create_release == 'true'
         env:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
         with:
@@ -111,17 +113,17 @@ jobs:
       - uses: actions/download-artifact@v2
         name: Download artifact
         id: download
-        if: env.CREATE_RELEASE
+        if: steps.vars.outputs.create_release == 'true'
         with:
-          name: $ARTIFACT_NAME
+          name: ${{steps.vars2.outputs.artifact_name}}
 
       - uses: actions/upload-release-asset@v1
         name: Upload Release Asset
-        if: env.CREATE_RELEASE
+        if: steps.vars.outputs.create_release == 'true'
         env:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
         with:
           upload_url: ${{steps.create_release.outputs.upload_url}} 
-          asset_path: ${{steps.download.outputs.download-path}}/$ARTIFACT_NAME.zip
-          asset_name: $ARTIFACT_NAME
+          asset_path: ${{steps.download.outputs.download-path}}/${{steps.vars2.outputs.artifact_name}}.zip
+          asset_name: ${{steps.vars2.outputs.artifact_name}}
           asset_content_type: application/zip

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -57,7 +57,7 @@ jobs:
 
           print(f'::set-output name=ARTIFACT_NAME::migrator-{version}-win-x64')
 
-          filepath = '${{github.workspace}}/windows/runner/Runner.rc'.replace('/', '//')
+          filepath = '${{github.workspace}}/windows/runner/Runner.rc'.replace('\\', '/')
           
           print(f'::debug Define version in {filepath}')
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -30,8 +30,6 @@ jobs:
         id: vars
         shell: python
         run: |
-          import subprocess
-
           srcBranch = '${{ github.head_ref || github.ref }}'.replace('refs/heads/', '').replace('/', '-')
           createArtifact = 'true' if srcBranch == 'master' or srcBranch == 'ci' else 'false'
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,6 +23,11 @@ jobs:
   build:
     runs-on: windows-latest
     steps:
+      - name: Dump GitHub context
+        env:
+          GITHUB_CONTEXT: ${{ toJson(github) }}
+        run: echo "$GITHUB_CONTEXT"
+
       - uses: actions/checkout@v2
         name: Checkout
 


### PR DESCRIPTION
- The executable file properties now has version number information
- Use python shell instead actions/github-script
- Not run the CI process on config and README file changes